### PR TITLE
Remove dependence on nokiaui

### DIFF
--- a/BounceTales/src/bouncetales/BounceGame.java
+++ b/BounceTales/src/bouncetales/BounceGame.java
@@ -1,8 +1,6 @@
 package bouncetales;
 
 import bouncetales.ext.rsc.ImageMap;
-import com.nokia.mid.ui.DirectGraphics;
-import com.nokia.mid.ui.DirectUtils;
 import java.util.Random;
 import javax.microedition.io.ConnectionNotFoundException;
 import javax.microedition.lcdui.Graphics;
@@ -631,7 +629,7 @@ public final class BounceGame {
 	}
 
 	/* renamed from: a */
-	private static void drawTranslucentSoftkeyBar(DirectGraphics directGraphics) {
+	private static void drawTranslucentSoftkeyBar(Graphics grp) {
 		int skbHeight = GameRuntime.getSoftkeyBarHeight();
 		int width = GameRuntime.currentWidth;
 		int height = GameRuntime.currentHeight - skbHeight;
@@ -643,7 +641,7 @@ public final class BounceGame {
 		xluSoftkeyBarYs[2] = height + skbHeight;
 		xluSoftkeyBarXs[3] = 0;
 		xluSoftkeyBarYs[3] = skbHeight + height;
-		directGraphics.fillPolygon(xluSoftkeyBarXs, 0, xluSoftkeyBarYs, 0, 4, 0x55000000);
+		GraphicsUtils.fillPolygonARGB(grp, xluSoftkeyBarXs, 0, xluSoftkeyBarYs, 0, 4, 0x55000000, true);
 	}
 
 	/* renamed from: a */
@@ -669,32 +667,32 @@ public final class BounceGame {
 
 	private static void cycleLevelSelectLeft(UILayout layout, boolean updateSoftkeys) {
 		if (selectedLevelId != 0) {
-			boolean fast = lastSelectedLevelId > selectedLevelId;
-			lastSelectedLevelId = selectedLevelId;
-			selectedLevelId--;
+                        boolean fast = lastSelectedLevelId > selectedLevelId;
+                        lastSelectedLevelId = selectedLevelId;
+                        selectedLevelId--;
 			if (bookAnimationTime == 650 || fast) {
 				bookAnimationTime = 0;
 			}
 			targetBookAnimationTime = 650;
-			if (updateSoftkeys) {
-				updateLevelStartSoftkeyByUnlock(layout);
-			}
+                        if (updateSoftkeys) {
+                                updateLevelStartSoftkeyByUnlock(layout);
+                        }
 		}
 	}
 
 	/* renamed from: a */
 	private static void cycleLevelSelectRight(UILayout layout, boolean updateSoftkeys) {
 		if (selectedLevelId != 14) {
-			boolean fast = lastSelectedLevelId < selectedLevelId;
-			lastSelectedLevelId = selectedLevelId;
-			selectedLevelId++;
+                        boolean fast = lastSelectedLevelId < selectedLevelId;
+                        lastSelectedLevelId = selectedLevelId;
+                        selectedLevelId++;
 			if (bookAnimationTime == 0 || fast) {
 				bookAnimationTime = 650;
 			}
 			targetBookAnimationTime = 0;
-			if (updateSoftkeys) {
-				updateLevelStartSoftkeyByUnlock(layout);
-			}
+                        if (updateSoftkeys) {
+                                updateLevelStartSoftkeyByUnlock(layout);
+                        }
 		}
 	}
 
@@ -771,7 +769,6 @@ public final class BounceGame {
 		GameRuntime.setBacklight(true);
 		Graphics grp = GameRuntime.getGraphicsObj();
 		int delta = GameRuntime.updateDelta * GameRuntime.getUpdatesPerDraw();
-		DirectGraphics directGraphics = DirectUtils.getDirectGraphics(grp);
 		if ((ui.uiID == GameScene.INFO_FIELD_MESSAGE
 				|| ui.uiID == GameScene.MENU_PAUSE
 				|| ui.uiID == GameScene.CONFIRM_RESTART_LEVEL
@@ -788,12 +785,12 @@ public final class BounceGame {
 			ypoints[2] = ypos + height;
 			xpoints[3] = xpos;
 			ypoints[3] = ypos + height;
-			directGraphics.fillPolygon(xpoints, 0, ypoints, 0, 4, 0x55000000);
+			GraphicsUtils.fillPolygonARGB(grp, xpoints, 0, ypoints, 0, 4, 0x55000000, true);
 			GameRuntime.drawImageRes(xpos, ypos, 311);
 			GameRuntime.drawImageRes(xpos + width, ypos, 312);
 			GameRuntime.drawImageRes(xpos, ypos + height, 309);
 			GameRuntime.drawImageRes(xpos + width, ypos + height, 310);
-			drawTranslucentSoftkeyBar(directGraphics);
+			drawTranslucentSoftkeyBar(grp);
 			return false;
 		} else if (ui.uiID == GameScene.MENU_LEVEL_SELECT) {
 			if (type == 1) {
@@ -869,10 +866,10 @@ public final class BounceGame {
 				GameRuntime.drawImageRes(9, 9, 102);
 				String stringBuffer = getTotalEggCount() + "/450";
 				GameRuntime.drawText(stringBuffer, 0, stringBuffer.length(), 41, 10, 20);
-				drawTranslucentSoftkeyBar(directGraphics);
+				drawTranslucentSoftkeyBar(grp);
 			}
 			return false;
-		} else if (ui.uiID == GameScene.MENU_PAUSE
+                } else if (ui.uiID == GameScene.MENU_PAUSE
 				|| ui.uiID == GameScene.CONFIRM_RESTART_LEVEL
 				|| ui.uiID == GameScene.CONFIRM_RETURN_LEVEL_SELECT
 				|| ui.uiID == GameScene.CONFIRM_EXIT_LEVEL
@@ -880,7 +877,7 @@ public final class BounceGame {
 				|| ui.uiID == GameScene.INFO_FIELD_MESSAGE
 				|| type != 1) {
 			if (type == 1) {
-				drawTranslucentSoftkeyBar(directGraphics);
+				drawTranslucentSoftkeyBar(grp);
 			}
 			if (type == 4 || type == 2 || type == 9) {
 				return false;
@@ -937,7 +934,7 @@ public final class BounceGame {
 			} else {
 				drawBookFrame(i20, i21, grp);
 			}
-			drawTranslucentSoftkeyBar(directGraphics);
+			drawTranslucentSoftkeyBar(grp);
 			return false;
 		}
 	}
@@ -1939,7 +1936,6 @@ public final class BounceGame {
 			if (this.gameMainState == 4) { //in-game
 				GameRuntime.setBacklight(true);
 				Graphics graphics = GameRuntime.getGraphicsObj();
-				DirectGraphics directGraphics = DirectUtils.getDirectGraphics(graphics);
 				graphics.setClip(0, 0, renderClipWidth, renderClipHeight);
 				int levelType = getLevelType(currentLevel);
 				short[] sArr4 = f307i;
@@ -2012,7 +2008,7 @@ public final class BounceGame {
 					drawBGParallax(sArr3, 80, 100, 150, 100, -70, 300, PARALLAX_MAX_COUNT * pscale, -1, graphics);
 				}
 				mRNG.setSeed(System.currentTimeMillis());
-				GameObject.drawSceneTree(rootLevelObj, graphics, directGraphics);
+				GameObject.drawSceneTree(rootLevelObj, graphics);
 				graphics.setClip(0, 0, GameRuntime.currentWidth, GameRuntime.currentHeight);
 				GameRuntime.setTextStyle(-3, 1);
 				GameRuntime.setTextColor(0, 0);
@@ -2528,7 +2524,7 @@ public final class BounceGame {
 						cycleLevelSelectRight(ui, true);
 						break;
 				}
-			}
+                        }
 			ui.handleKeyCode(keyCode);
 		} else if (this.gameMainState == 2) {
 			updateLoadingScreen();

--- a/BounceTales/src/bouncetales/BounceObject.java
+++ b/BounceTales/src/bouncetales/BounceObject.java
@@ -1,6 +1,5 @@
 package bouncetales;
 
-import com.nokia.mid.ui.DirectGraphics;
 import javax.microedition.lcdui.Graphics;
 
 /* renamed from: c */
@@ -682,8 +681,8 @@ public final class BounceObject extends GameObject {
 	// p000.GameObject
 	/* renamed from: a */
 	//@Override
-	public final void draw(Graphics graphics, DirectGraphics directGraphics, Matrix rootMatrix) {
-		super.draw(graphics, directGraphics, rootMatrix);
+	public final void draw(Graphics graphics, Matrix rootMatrix) {
+		super.draw(graphics, rootMatrix);
 		int fbBallCY;
 		int fbBallCX;
 		Graphics graphics2;

--- a/BounceTales/src/bouncetales/CannonObject.java
+++ b/BounceTales/src/bouncetales/CannonObject.java
@@ -1,6 +1,5 @@
 package bouncetales;
 
-import com.nokia.mid.ui.DirectGraphics;
 import javax.microedition.lcdui.Graphics;
 
 /* renamed from: k */
@@ -74,8 +73,8 @@ public final class CannonObject extends GameObject {
 	// p000.GameObject
 	/* renamed from: a */
 	//@Override
-	public final void draw(Graphics graphics, DirectGraphics directGraphics, Matrix dVar) {
-		super.draw(graphics, directGraphics, dVar);
+	public final void draw(Graphics graphics, Matrix dVar) {
+		super.draw(graphics, dVar);
 		if (this.animCountdown > 0) {
 			int currentCannonFrame = CANNON_TOTAL_FRAMES - this.animCountdown;
 			int frameStartFrames = 0;
@@ -109,7 +108,7 @@ public final class CannonObject extends GameObject {
 			model.localObjectMatrix.m01 = this.localObjectMatrix.m01;
 			model.localObjectMatrix.m11 = this.localObjectMatrix.m11;
 			model.setIsDirtyRecursive();
-			model.draw(graphics, directGraphics, dVar);
+			model.draw(graphics, dVar);
 		}
 		GameRuntime.drawImageRes(imageX, imageY, 48);
 	}

--- a/BounceTales/src/bouncetales/EggObject.java
+++ b/BounceTales/src/bouncetales/EggObject.java
@@ -1,6 +1,5 @@
 package bouncetales;
 
-import com.nokia.mid.ui.DirectGraphics;
 import javax.microedition.lcdui.Graphics;
 
 /* renamed from: a */
@@ -32,7 +31,7 @@ public final class EggObject extends GameObject {
 	// p000.GameObject
 	/* renamed from: a */
 	//@Override
-	public final void draw(Graphics graphics, DirectGraphics directGraphics, Matrix dVar) {
+	public final void draw(Graphics graphics, Matrix dVar) {
 		loadObjectMatrixToTarget(GameObject.tmpObjMatrix);
 		Matrix.multMatrices(dVar, GameObject.tmpObjMatrix, Matrix.temp);
 		GameRuntime.drawImageRes(Matrix.temp.translationX >> 16, Matrix.temp.translationY >> 16, 208);

--- a/BounceTales/src/bouncetales/EnemyObject.java
+++ b/BounceTales/src/bouncetales/EnemyObject.java
@@ -1,6 +1,5 @@
 package bouncetales;
 
-import com.nokia.mid.ui.DirectGraphics;
 import javax.microedition.lcdui.Graphics;
 
 /* renamed from: l */
@@ -126,7 +125,7 @@ public final class EnemyObject extends GameObject {
 	// p000.GameObject
 	/* renamed from: a */
 	//@Override
-	public final void draw(Graphics graphics, DirectGraphics directGraphics, Matrix rootMatrix) {
+	public final void draw(Graphics graphics, Matrix rootMatrix) {
 		loadObjectMatrixToTarget(GameObject.tmpObjMatrix);
 		Matrix.multMatrices(rootMatrix, GameObject.tmpObjMatrix, Matrix.temp);
 		int posX = Matrix.temp.translationX >> 16;

--- a/BounceTales/src/bouncetales/EventObject.java
+++ b/BounceTales/src/bouncetales/EventObject.java
@@ -1,6 +1,5 @@
 package bouncetales;
 
-import com.nokia.mid.ui.DirectGraphics;
 import javax.microedition.lcdui.Graphics;
 
 /* renamed from: g */
@@ -81,7 +80,7 @@ public final class EventObject extends GameObject {
 	// p000.GameObject
 	/* renamed from: a */
 	//@Override
-	public final void draw(Graphics graphics, DirectGraphics directGraphics, Matrix rootMatrix) {
+	public final void draw(Graphics graphics, Matrix rootMatrix) {
 		if (DEBUG_DRAW_ON) {
 			int[] colors = new int[]{0x0000FF, 0xFF0000, 0x00FF00, 0x00CC00};
 			debugDraw(graphics, colors[eventState], rootMatrix);

--- a/BounceTales/src/bouncetales/GameObject.java
+++ b/BounceTales/src/bouncetales/GameObject.java
@@ -1,6 +1,5 @@
 package bouncetales;
 
-import com.nokia.mid.ui.DirectGraphics;
 import javax.microedition.lcdui.Graphics;
 
 /* renamed from: j */
@@ -231,7 +230,7 @@ public class GameObject {
 	}
 
 	/* renamed from: a */
-	public void draw(Graphics graphics, DirectGraphics directGraphics, Matrix rootMatrix) {
+	public void draw(Graphics graphics, Matrix rootMatrix) {
 
 	}
 
@@ -291,7 +290,7 @@ public class GameObject {
 	protected static int[] screenAABB = new int[4];
 
 	/* renamed from: a */
-	public static void drawSceneTree(GameObject root, Graphics g, DirectGraphics dg) {
+	public static void drawSceneTree(GameObject root, Graphics g) {
 		getWorldMatrix(rootMatrix);
 		rootMatrix.invert(inverseRootMatrix);
 		getScreenWorldAABB(inverseRootMatrix, screenAABB);
@@ -322,7 +321,7 @@ public class GameObject {
 			}
 		}
 		for (int i = 0; i < renderObjCount; i++) {
-			objectsToRender[i].draw(g, dg, rootMatrix);
+			objectsToRender[i].draw(g, rootMatrix);
 		}
 		renderObjCount = 0;
 		for (int i = 0; i < objectsToRender.length; i++) {

--- a/BounceTales/src/bouncetales/GameRuntime.java
+++ b/BounceTales/src/bouncetales/GameRuntime.java
@@ -6,7 +6,6 @@ import bouncetales.ext.rsc.ResidentResHeader;
 import bouncetales.ext.rsc.ResourceBatch;
 import bouncetales.ext.rsc.ResourceInfo;
 import bouncetales.ext.rsc.ResourceType;
-import com.nokia.mid.ui.DeviceControl;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
@@ -15,10 +14,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Vector;
 import javax.microedition.lcdui.Canvas;
-import javax.microedition.lcdui.Command;
-import javax.microedition.lcdui.CommandListener;
 import javax.microedition.lcdui.Display;
-import javax.microedition.lcdui.Displayable;
 import javax.microedition.lcdui.Font;
 import javax.microedition.lcdui.Graphics;
 import javax.microedition.lcdui.Image;
@@ -33,7 +29,7 @@ import javax.microedition.rms.RecordStore;
 import javax.microedition.rms.RecordStoreException;
 
 /* renamed from: o */
-public final class GameRuntime extends GameCanvas implements Runnable, CommandListener, IResourceHandler {
+public final class GameRuntime extends GameCanvas implements Runnable, IResourceHandler {
 
 	/*
 	Constants
@@ -209,6 +205,7 @@ public final class GameRuntime extends GameCanvas implements Runnable, CommandLi
 
 	public GameRuntime() {
 		super(false);
+                GraphicsUtils.init();
 	}
 
 	public static void resetGlobalState() {
@@ -918,7 +915,8 @@ public final class GameRuntime extends GameCanvas implements Runnable, CommandLi
 					paintDebugOverlay(graphics);
 				}
 			} catch (Throwable th) {
-				th.printStackTrace();
+                                drawErr(graphics, th);
+                                th.printStackTrace();
 			}
 		}
 	}
@@ -926,14 +924,16 @@ public final class GameRuntime extends GameCanvas implements Runnable, CommandLi
 	/* renamed from: j */
 	private void callGamePaint(int mode) {
 		paintMode = mode;
-		gamePaint(mInstance.getGraphics());
-		mInstance.flushGraphics();
+		gamePaint(getGraphics());
+		flushGraphics();
 		paintMode = 0;
 	}
 
 	/* renamed from: b */
 	public static void setBacklight(boolean isOn) {
-		DeviceControl.setLights(0, isOn ? 100 : 0);
+                try {
+                        com.nokia.mid.ui.DeviceControl.setLights(0, isOn ? 100 : 0);
+                } catch (NoClassDefFoundError err) {}
 	}
 
 	/* renamed from: b */
@@ -1752,9 +1752,6 @@ public final class GameRuntime extends GameCanvas implements Runnable, CommandLi
 		}
 	}
 
-	public final void commandAction(Command command, Displayable displayable) {
-	}
-
 	//@Override
 	protected final void showNotify() {
 		setState(GameState.SHOWN);
@@ -1905,6 +1902,7 @@ public final class GameRuntime extends GameCanvas implements Runnable, CommandLi
 						}
 					} catch (Throwable th) {
 						th.printStackTrace();
+                                                drawErr(getGraphicsObj(), th);
 					}
 				} //end game loop
 			}
@@ -1921,9 +1919,15 @@ public final class GameRuntime extends GameCanvas implements Runnable, CommandLi
 			m.notifyDestroyed();
 		} catch (Throwable th2) {
 			th2.printStackTrace();
+                        drawErr(getGraphicsObj(), th2);
 		}
 		System.out.println("BounceThread died");
 	}
+
+        private void drawErr(Graphics g, Throwable th) {
+            g.setColor(0xff0000);
+            g.drawString(th.toString(), 0, 30, Graphics.LEFT | Graphics.TOP);
+        }
 
 	/* renamed from: l */
 	private static void waitPausedRuntime() {

--- a/BounceTales/src/bouncetales/GeometryObject.java
+++ b/BounceTales/src/bouncetales/GeometryObject.java
@@ -1,6 +1,5 @@
 package bouncetales;
 
-import com.nokia.mid.ui.DirectGraphics;
 import javax.microedition.lcdui.Graphics;
 
 /* renamed from: p */
@@ -87,7 +86,7 @@ public final class GeometryObject extends GameObject {
 	// p000.GameObject
 	/* renamed from: a */
 	//@Override
-	public final void draw(Graphics graphics, DirectGraphics directGraphics, Matrix rootMatrix) {
+	public final void draw(Graphics graphics, Matrix rootMatrix) {
 		if (geometryTransformIsDirty) {
 			loadObjectMatrixToTarget(GameObject.tmpObjMatrix);
 			int tx = rootMatrix.translationX;

--- a/BounceTales/src/bouncetales/GraphicsUtils.java
+++ b/BounceTales/src/bouncetales/GraphicsUtils.java
@@ -10,9 +10,7 @@ import javax.microedition.lcdui.Image;
 public class GraphicsUtils {
 
         public static boolean isDirectGraphicsSupported = false;
-
-        // Too laggy, so it is disabled by default
-        public static boolean enableWaterNoDirectGraphicsWorkaround = false;
+        public static boolean enableWaterNoDirectGraphicsWorkaround = true;
 
         public static void init() {
                 System.out.println("Testing nokiaui support...");
@@ -38,31 +36,67 @@ public class GraphicsUtils {
 
         // A workaround for drawing translucent polygons (pause menu and softkey bar bg, water) on phones that don't support nokiaui
         public static void fillPolygonNoDirectGraphics(Graphics g, int[] xPoints, int xOffset, int[] yPoints, int yOffset, int nPoints, int argbColor) {
+                int alpha = argbColor & 0xff000000;
+
                 int w = g.getClipWidth();
                 int h = g.getClipHeight();
-                int rgbColor = argbColor % 0x01000000;
-                int alpha = argbColor - rgbColor;
-                int prevColor = g.getColor();
-                g.setColor(rgbColor);
+
+                int x0 = w;
+                int y0 = h;
+                int xMax = 0;
+                int yMax = 0;
+
+                for (int i = xOffset; i < nPoints + xOffset; i++) {
+                        x0 = Math.min(x0, xPoints[i]);
+                        xMax = Math.max(xMax, xPoints[i]);
+                }
+
+                for (int i = yOffset; i < nPoints + yOffset; i++) {
+                        y0 = Math.min(y0, yPoints[i]);
+                        yMax = Math.max(yMax, yPoints[i]);
+                }
+
+                x0 = Math.max(x0, 0);
+                y0 = Math.max(y0, 0);
+                xMax = Math.min(xMax, w);
+                yMax = Math.min(yMax, h);
+
+                w = xMax - x0;
+                h = yMax - y0;
+
+                if (w <= 0 || h <= 0) {
+                        return;
+                }
+
                 Image buffer = Image.createImage(w, h);
                 Graphics bufGraphics = buffer.getGraphics();
-                bufGraphics.setColor(rgbColor);
+
+                int transparencyMarker = bufGraphics.getDisplayColor(0x123456);
+                bufGraphics.setColor(transparencyMarker);
+                bufGraphics.fillRect(0, 0, buffer.getWidth(), buffer.getHeight());
+
+                bufGraphics.setColor(argbColor);
                 for (int i = 1; i < nPoints - 1; i++) {
                         int ix = i + xOffset;
                         int iy = i + yOffset;
-                        bufGraphics.fillTriangle(xPoints[xOffset], yPoints[yOffset], xPoints[ix], yPoints[iy], xPoints[ix+1], yPoints[iy+1]);
+                        bufGraphics.fillTriangle(
+                                        xPoints[xOffset] - x0, yPoints[yOffset] - y0,
+                                        xPoints[ix] - x0, yPoints[iy] - y0,
+                                        xPoints[ix+1] - x0, yPoints[iy+1] - y0
+                        );
                 }
+
                 int[] rgbData = new int[w*h];
                 buffer.getRGB(rgbData, 0, w, 0, 0, w, h);
-                applyAlpha(rgbData, alpha);
-                g.setColor(prevColor);
-                g.drawRGB(rgbData, 0, w, 0, 0, g.getClipWidth(), g.getClipHeight(), true);
+                applyAlpha(rgbData, alpha, transparencyMarker);
+
+                g.drawRGB(rgbData, 0, w, x0, y0, w, h, true);
         }
 
-        public static void applyAlpha(int[] rgbData, int alpha) {
+        public static void applyAlpha(int[] rgbData, int alpha, int transparentBgColor) {
                 int antialpha = 0xff000000 - alpha;
                 for (int i = 0; i < rgbData.length; i++) {
-                        if (rgbData[i] == 0xffffffff) {
+                        if ((rgbData[i] & 0x00ffffff) == transparentBgColor) {
                                 rgbData[i] = 0x00000000;
                         } else {
                                 rgbData[i] -= antialpha;

--- a/BounceTales/src/bouncetales/GraphicsUtils.java
+++ b/BounceTales/src/bouncetales/GraphicsUtils.java
@@ -1,0 +1,72 @@
+package bouncetales;
+
+import javax.microedition.lcdui.Graphics;
+import javax.microedition.lcdui.Image;
+
+/**
+ *
+ * @author vipaol
+ */
+public class GraphicsUtils {
+
+        public static boolean isDirectGraphicsSupported = false;
+
+        // Too laggy, so it is disabled by default
+        public static boolean enableWaterNoDirectGraphicsWorkaround = false;
+
+        public static void init() {
+                System.out.println("Testing nokiaui support...");
+                try {
+                        Class.forName("com.nokia.mid.ui.DirectGraphics");
+                        System.out.println("DirectGraphics is supported");
+                        isDirectGraphicsSupported = true;
+                } catch (ClassNotFoundException ex) {
+                        System.out.println("no DirectGraphics");
+                        isDirectGraphicsSupported = false;
+                }
+        }
+
+        public static void fillPolygonARGB(Graphics g, int[] xPoints, int xOffset, int[] yPoints, int yOffset, int nPoints, int argbColor, boolean force) {
+                if (isDirectGraphicsSupported) {
+                        com.nokia.mid.ui.DirectUtils.getDirectGraphics(g).fillPolygon(xPoints, xOffset, yPoints, yOffset, nPoints, argbColor);
+                } else {
+                        if (enableWaterNoDirectGraphicsWorkaround || force) {
+                                fillPolygonNoDirectGraphics(g, xPoints, xOffset, yPoints, yOffset, nPoints, argbColor);
+                        }
+                }
+        }
+
+        // A workaround for drawing translucent polygons (pause menu and softkey bar bg, water) on phones that don't support nokiaui
+        public static void fillPolygonNoDirectGraphics(Graphics g, int[] xPoints, int xOffset, int[] yPoints, int yOffset, int nPoints, int argbColor) {
+                int w = g.getClipWidth();
+                int h = g.getClipHeight();
+                int rgbColor = argbColor % 0x01000000;
+                int alpha = argbColor - rgbColor;
+                int prevColor = g.getColor();
+                g.setColor(rgbColor);
+                Image buffer = Image.createImage(w, h);
+                Graphics bufGraphics = buffer.getGraphics();
+                bufGraphics.setColor(rgbColor);
+                for (int i = 1; i < nPoints - 1; i++) {
+                        int ix = i + xOffset;
+                        int iy = i + yOffset;
+                        bufGraphics.fillTriangle(xPoints[xOffset], yPoints[yOffset], xPoints[ix], yPoints[iy], xPoints[ix+1], yPoints[iy+1]);
+                }
+                int[] rgbData = new int[w*h];
+                buffer.getRGB(rgbData, 0, w, 0, 0, w, h);
+                applyAlpha(rgbData, alpha);
+                g.setColor(prevColor);
+                g.drawRGB(rgbData, 0, w, 0, 0, g.getClipWidth(), g.getClipHeight(), true);
+        }
+
+        public static void applyAlpha(int[] rgbData, int alpha) {
+                int antialpha = 0xff000000 - alpha;
+                for (int i = 0; i < rgbData.length; i++) {
+                        if (rgbData[i] == 0xffffffff) {
+                                rgbData[i] = 0x00000000;
+                        } else {
+                                rgbData[i] -= antialpha;
+                        }
+                }
+        }
+}

--- a/BounceTales/src/bouncetales/ParticleObject.java
+++ b/BounceTales/src/bouncetales/ParticleObject.java
@@ -1,6 +1,5 @@
 package bouncetales;
 
-import com.nokia.mid.ui.DirectGraphics;
 import javax.microedition.lcdui.Graphics;
 
 /* renamed from: n */
@@ -89,7 +88,7 @@ public final class ParticleObject extends GameObject {
 	// p000.GameObject
 	/* renamed from: a */
 	//@Override
-	public final void draw(Graphics graphics, DirectGraphics directGraphics, Matrix rootMatrix) {
+	public final void draw(Graphics graphics, Matrix rootMatrix) {
 		boolean lifespanEnd;
 		int i;
 		int delta = GameRuntime.updateDelta * GameRuntime.getUpdatesPerDraw();

--- a/BounceTales/src/bouncetales/SpriteObject.java
+++ b/BounceTales/src/bouncetales/SpriteObject.java
@@ -1,7 +1,6 @@
 package bouncetales;
 
 import bouncetales.ext.rsc.ImageMap;
-import com.nokia.mid.ui.DirectGraphics;
 import javax.microedition.lcdui.Graphics;
 
 /* renamed from: r */
@@ -48,7 +47,7 @@ public final class SpriteObject extends GameObject {
 				}
 			}
 			pos = decomposeBytesToShorts(this.imageIDs, count, 0, 1, bArr, pos, 16);
-			for (int i = 0; i < count; i++) {
+                        for (int i = 0; i < count; i++) {
 				this.actionImageIDs[i] = -1;
 			}
 		}
@@ -91,8 +90,8 @@ public final class SpriteObject extends GameObject {
 	// p000.GameObject
 	/* renamed from: a */
 	//@Override 
-	public final void draw(Graphics graphics, DirectGraphics directGraphics, Matrix rootMatrix) {
-		super.draw(graphics, directGraphics, rootMatrix);
+	public final void draw(Graphics graphics, Matrix rootMatrix) {
+		super.draw(graphics, rootMatrix);
 		int anmTime;
 		int fadeColor;
 		int actYPos;

--- a/BounceTales/src/bouncetales/StringManager.java
+++ b/BounceTales/src/bouncetales/StringManager.java
@@ -3,7 +3,6 @@ package bouncetales;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Vector;
 
 /* renamed from: q */
 public final class StringManager {
@@ -12,61 +11,6 @@ public final class StringManager {
 	private static String localeProperty = null; //renamed from: a
 	
 	private static DataInputStream textReader = null; //renamed from: a
-
-	static {
-		System.out.println("LocalizedData init...");
-		boolean matchedPlatform = false;
-		String platformProperty = System.getProperty("microedition.platform");
-		StringBuffer sb = new StringBuffer();
-		InputStream manifestStrm = StringManager.class.getResourceAsStream("/META-INF/MANIFEST.MF");
-		if (manifestStrm != null) {
-			while (true) {
-				try {
-					int read = manifestStrm.read();
-					if (read < 0) {
-						break;
-					} else if (((char) read) == '\r') {
-						continue;
-					} else if (((char) read) != '\n') {
-						sb.append((char) read);
-					} else if (sb.toString().trim().startsWith("Nokia-Platform:")) {
-						sb.append(readPropertyValue(manifestStrm));
-						String nokiaPlatform = sb.toString().trim().substring("Nokia-Platform:".length());
-						System.out.println("Check Nokia-Platform " + nokiaPlatform + " against " + platformProperty);
-						Vector nokiaPlatforms = new Vector();
-						while (true) {
-							int indexOf = nokiaPlatform.indexOf("@");
-							if (indexOf == -1) {
-								break;
-							}
-							nokiaPlatforms.addElement(nokiaPlatform.substring(0, indexOf));
-							nokiaPlatform = nokiaPlatform.substring(indexOf + 1, nokiaPlatform.length());
-						}
-						nokiaPlatforms.addElement(nokiaPlatform);
-						for (int i = 0; i < nokiaPlatforms.size(); i++) {
-							String plaf = (String) nokiaPlatforms.elementAt(i);
-							if (checkNokiaPlatform(platformProperty, plaf.trim(), 0, 0)) {
-								matchedPlatform = true;
-								break;
-							}
-						}
-						break;
-					} else {
-						sb.delete(0, sb.length());
-					}
-				} catch (IOException e) {
-					e.printStackTrace();
-					break;
-				}
-			}
-		}
-		if (!matchedPlatform) {
-			System.out.println("LocalizedData init failure!");
-			System.exit(0);
-		} else {
-			System.out.println("LocalizedData init success.");
-		}
-	}
 
 	private StringManager() {
 	}
@@ -155,63 +99,5 @@ public final class StringManager {
 			indexOf = str.indexOf(toFind);
 		}
 		return str;
-	}
-
-	/* renamed from: a */
-	private static StringBuffer readPropertyValue(final InputStream inputStream) {
-		final StringBuffer sb = new StringBuffer();
-		try {
-			if ((char) inputStream.read() != ' ') {
-				return sb;
-			}
-			char character;
-			while ((character = (char) inputStream.read()) != -1) {
-				if (character != '\r') {
-					if (character == '\n') {
-						sb.append((Object) readPropertyValue(inputStream));
-						break;
-					}
-					sb.append(character);
-				}
-			}
-		} catch (IOException ex) {
-			ex.printStackTrace();
-		}
-		return sb;
-	}
-
-	/* renamed from: a */
-	private static boolean checkNokiaPlatform(String platform, String filter, int offsetPlatform, int offsetFilter) {
-		if (platform == null) {
-			return true; //running most likely on a PC
-		}
-		while (true) {
-			if (offsetPlatform == platform.length() && offsetFilter == filter.length()) {
-				return true;
-			}
-			if (offsetPlatform != platform.length() && offsetFilter != filter.length()) {
-				switch (filter.charAt(offsetFilter)) {
-					case '*':
-						if (offsetFilter != filter.length() - 1 && !checkNokiaPlatform(platform, filter, offsetPlatform, offsetFilter + 1)) {
-							offsetPlatform++;
-						} else {
-							return true;
-						}
-						break;
-					case '?':
-						offsetPlatform++;
-						offsetFilter++;
-						break;
-					default:
-						if (platform.charAt(offsetPlatform) == filter.charAt(offsetFilter)) {
-							offsetPlatform++;
-							offsetFilter++;
-						} else {
-							return false;
-						}
-						break;
-				}
-			}
-		}
 	}
 }

--- a/BounceTales/src/bouncetales/TrampolineObject.java
+++ b/BounceTales/src/bouncetales/TrampolineObject.java
@@ -1,6 +1,5 @@
 package bouncetales;
 
-import com.nokia.mid.ui.DirectGraphics;
 import javax.microedition.lcdui.Graphics;
 
 /* renamed from: e */
@@ -66,7 +65,7 @@ public final class TrampolineObject extends GameObject {
 	// p000.GameObject
 	/* renamed from: a */
 	//@Override
-	public final void draw(Graphics graphics, DirectGraphics directGraphics, Matrix rootMatrix) {
+	public final void draw(Graphics graphics, Matrix rootMatrix) {
 		loadObjectMatrixToTarget(GameObject.tmpObjMatrix);
 		Matrix.multMatrices(rootMatrix, GameObject.tmpObjMatrix, Matrix.temp);
 		GameRuntime.drawAnimatedImageRes(Matrix.temp.translationX >> 16, Matrix.temp.translationY >> 16, this.imageId, this.animFrame);

--- a/BounceTales/src/bouncetales/WaterObject.java
+++ b/BounceTales/src/bouncetales/WaterObject.java
@@ -1,6 +1,5 @@
 package bouncetales;
 
-import com.nokia.mid.ui.DirectGraphics;
 import javax.microedition.lcdui.Graphics;
 
 /* renamed from: i */
@@ -129,7 +128,7 @@ public final class WaterObject extends GameObject {
 	// p000.GameObject
 	/* renamed from: a */
 	//@Override
-	public final void draw(Graphics graphics, DirectGraphics directGraphics, Matrix rootMatrix) {
+	public final void draw(Graphics graphics, Matrix rootMatrix) {
 		int airEmitDir;
 		int airYMax;
 		int airXMin;
@@ -249,7 +248,7 @@ public final class WaterObject extends GameObject {
 					nPoints++;
 					vertIdx++;
 				}
-				directGraphics.fillPolygon(xPoints, 0, yPoints, 0, nPoints, BounceGame.getStolenColorIfApplicable(this.color));
+                                GraphicsUtils.fillPolygonARGB(graphics, xPoints, 0, yPoints, 0, nPoints, BounceGame.getStolenColorIfApplicable(this.color), false);
 			} else {
 				int[] polyX = GeometryObject.TEMP_QUAD_XS;
 				int[] polyY = GeometryObject.TEMP_QUAD_YS;
@@ -261,7 +260,7 @@ public final class WaterObject extends GameObject {
 				polyY[2] = maxy;
 				polyX[3] = minx;
 				polyY[3] = maxy;
-				directGraphics.fillPolygon(polyX, 0, polyY, 0, 4, BounceGame.getStolenColorIfApplicable(this.color));
+                                GraphicsUtils.fillPolygonARGB(graphics, polyX, 0, polyY, 0, 4, BounceGame.getStolenColorIfApplicable(this.color), false);
 			}
 		} else if (!BounceGame.levelPaused) { //air tunnel
 			this.ambientParticleTimer += delta;


### PR DESCRIPTION
Remove dependence on nokiaui and checking for supported Nokia platforms (now will work on phones that don't support nokiaui), removed unused CommandListener in GameRuntime

nokiaui was used for drawing translucent polygons (for bg of buttons and pause menu and for water) and to control backlight. I've written my own realization of transparency, it is now used for drawing UI, but not for drawing water because this workaround is too slow to give reasonable FPS. Now I can play Bounce Tales on my Samsung C3200. It also works on Sun WTK emulator.

However, nothing had changed for phones that supports nokiaui. nokiaui is still being used for them